### PR TITLE
Handle NAs in ranef output

### DIFF
--- a/R/rqRes.r
+++ b/R/rqRes.r
@@ -157,11 +157,10 @@ rqResM = function(umFit) {
 }
 
 rqResO = function(umFit) {
-  rN = integer(nrow(umFit@data@y)) + NA
-  if (length(umFit@sitesRemoved) > 0)
-    rN[-umFit@sitesRemoved] = apply(unmarked::ranef(umFit)@post[,,1], 1 , sample, x = umFit@K + 1, size = 1, replace = FALSE) - 1
-  else
-    rN = apply(unmarked::ranef(umFit)@post[,,1], 1 , sample, x = umFit@K + 1, size = 1, replace = FALSE) - 1
+  rN = apply(unmarked::ranef(umFit)@post[,,1], 1 , function(z){
+    if(any(is.na(z))) return(NA)
+    sample(z, x = umFit@K+1, size = 1, replace=FALSE) -1
+  })
   p = unmarked::getP(umFit, na.rm = FALSE)
   res = rqRes(umFit@data@y, pFun = stats::pbinom, size = kronecker(rN, t(rep(1, ncol(p)))), prob = p)
   # if (any(is.infinite(res))) {
@@ -261,13 +260,19 @@ chatS = function(umFit) {
 
 chatO = function(umFit) {
   p = unmarked::getP(umFit, na.rm = FALSE)
+  rpost = unmarked::ranef(umFit)@post[,,1]
   if (length(umFit@sitesRemoved) > 0) {
     y = umFit@data@y[-umFit@sitesRemoved,]
     p = p[-umFit@sitesRemoved, ]
+    # if missing rows were not already removed from ranef output
+    if(nrow(rpost) > nrow(y)){
+      rpost = rpost[-umFit@sitesRemoved,,drop=FALSE]
+      stopifnot(nrow(rpost) == nrow(y))
+    }
   } else {
     y = umFit@data@y
   }
-  rN = apply(unmarked::ranef(umFit)@post[,,1], 1 , sample, x = umFit@K + 1, size = 1, replace = FALSE) - 1
+  rN = apply(rpost, 1 , sample, x = umFit@K + 1, size = 1, replace = FALSE) - 1
   naMat = (is.finite(y + p))
   naMat[which(naMat != 1)] = NA
   obs.site = apply(y * naMat, 1, sum, na.rm = TRUE)


### PR DESCRIPTION
In the next `unmarked` CRAN release (hopefully), I'm standardizing NA handling behavior across various `unmarked` methods. Among these changes will be that `ranef` will no longer silently drop sites with no observations from the output, which means it will now be possible to have rows with all missing values in the `ranef` output.

Based on my tests this causes errors (ultimately from `sample`) in the following functions in `nmixgof`:

* rqRes0
* chat0

This pull request adds code to work around the problem and should work with both the current CRAN release of `unmarked` and the future one. However my tests were limited to running and modifying the examples. I think the other functions are OK because they use `fitted`, which already does not drop sites by default.

I plan to send the new version of `unmarked` to CRAN in 4-6 months.

Thanks

Ken
